### PR TITLE
Use stable Socket.IO connection

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -31,6 +31,7 @@ function getStatusData(leads) {
 function App() {
   const { colorMode, toggleColorMode } = useColorMode();
   const formRef = useRef(null);
+  const socketRef = useRef(null);
 
   const bg = useColorModeValue("#f9fafb", "#1a202c");
   const cardBg = useColorModeValue("white", "gray.800");
@@ -43,13 +44,18 @@ function App() {
   const [filter, setFilter] = useState(() => localStorage.getItem("leadFilter") || "All");
   const [modalView, setModalView] = useState(null);
 
-  const socket = io('http://localhost:3000', { transports: ['websocket'] });
-
   useEffect(() => {
+    const socket = io('http://localhost:3000', { transports: ['websocket'] });
+    socketRef.current = socket;
+
     socket.on('call-ended', ({ to }) => {
       setLeads(prev => prev.map(lead => lead.phone === to ? { ...lead, callInProgress: false } : lead));
     });
-    return () => socket.off('call-ended');
+
+    return () => {
+      socket.off('call-ended');
+      socket.disconnect();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- create persistent Socket.IO client using `useEffect`/`useRef`
- ensure call-ended listener uses stable socket and cleans up

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 97 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4259b988327b74b28eb5bcc05d0