### PR TITLE
Remove unused onRealCall prop

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 // App.jsx
 import {
   Box, Container, Stack, HStack, VStack, Flex, Text, Button, IconButton,
-  Collapse, useColorMode, useColorModeValue, Icon, Image, Divider,
+  Collapse, useColorMode, useColorModeValue, Image,
   Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalCloseButton,
   SimpleGrid, Tooltip as ChakraTooltip
 } from "@chakra-ui/react";
@@ -81,21 +81,6 @@ function App() {
     setLeads(prev => prev.map(l => l.id === updated.id ? updated : l));
   };
 
-  const initiateRealCall = async (lead) => {
-    try {
-      const res = await fetch("http://localhost:3000/api/phone/call", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phoneNumber: lead.phone, leadId: lead.id }),
-      });
-      const data = await res.json();
-      if (res.ok) alert(`✅ Call initiated to ${lead.firstName}`);
-      else alert(`❌ Call failed: ${data.error}`);
-    } catch (err) {
-      alert("⚠️ Network error while initiating call.");
-    }
-  };
-
   return (
     <Box bg={bg} minH="100vh">
       {/* NAVBAR */}
@@ -156,7 +141,7 @@ function App() {
           </Stack>
 
           <Collapse in={showLeads}>
-            <LeadList leads={leads} onUpdateLead={updateLead} filter={filter} onRealCall={initiateRealCall} />
+            <LeadList leads={leads} onUpdateLead={updateLead} filter={filter} />
           </Collapse>
 
           {!showLeads && (

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -21,7 +21,7 @@ const STATUS_LABELS = {
   New: "🆕 New",
 };
 
-export default function LeadList({ leads, onUpdateLead, scrollRef, onRealCall, filter = "All" }) {
+export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All" }) {
   const borderColor = useColorModeValue("gray.200", "gray.700");
   const headerBg = useColorModeValue("gray.100", "gray.700");
 
@@ -91,7 +91,6 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, onRealCall, f
                     key={lead.id}
                     lead={lead}
                     onUpdateLead={onUpdateLead}
-                    onRealCall={onRealCall}
                     scrollRef={idx === grouped[status].length - 1 ? scrollRef : null}
                   />
                 ))}


### PR DESCRIPTION
## Summary
- Let `LeadCard` manage calls internally and stop propagating an `onRealCall` handler
- Drop `initiateRealCall` function and related prop usage in `App`/`LeadList`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/App.jsx src/components/LeadList.jsx` *(fails: React hook and prop validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e88c39448327bd356328d2626406