### PR TITLE
Ensure logger creates directory and handles errors

### DIFF
--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -6,5 +6,11 @@ const logFilePath = path.join(process.cwd(), 'server/logs/actions.log');
 export const logAction = (type, message) => {
   const timestamp = new Date().toISOString();
   const entry = `[${timestamp}] [${type}] ${message}\n`;
-  fs.appendFileSync(logFilePath, entry);
+  try {
+    fs.mkdirSync(path.dirname(logFilePath), { recursive: true });
+    fs.appendFileSync(logFilePath, entry);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to write log entry', error);
+  }
 };


### PR DESCRIPTION
## Summary
- Create log directory before appending entries
- Wrap log file writes in try/catch to avoid crashes

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b9eec6f15483279d0a3767157bbebc