### PR TITLE
Use route parameter for lead updates

### DIFF
--- a/server/controllers/leadController.js
+++ b/server/controllers/leadController.js
@@ -59,7 +59,8 @@ export const addLead = (req, res) => {
 // PUT /api/leads/:id
 export const updateLead = (req, res) => {
   try {
-    const { id, note, tags, followUpDate, answers, ...rest } = req.body;
+    const id = Number(req.params.id);
+    const { id: _unusedId, note, tags, followUpDate, answers, ...rest } = req.body;
     const leads = readDataFile(leadsFile);
     const index = leads.findIndex(lead => lead.id === id);
 


### PR DESCRIPTION
## Summary
- Read lead ID from request parameters in `updateLead` controller and ensure lookup uses numeric ID

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6923d208327b337690c4452015a