### PR TITLE
Refactor LeadCard to accept injected socket

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -141,7 +141,7 @@ function App() {
           </Stack>
 
           <Collapse in={showLeads}>
-            <LeadList leads={leads} onUpdateLead={updateLead} filter={filter} />
+            <LeadList leads={leads} onUpdateLead={updateLead} filter={filter} socket={socketRef.current} />
           </Collapse>
 
           {!showLeads && (

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -21,7 +21,7 @@ const STATUS_LABELS = {
   New: "🆕 New",
 };
 
-export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All" }) {
+export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All", socket }) {
   const borderColor = useColorModeValue("gray.200", "gray.700");
   const headerBg = useColorModeValue("gray.100", "gray.700");
 
@@ -92,6 +92,7 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All
                     lead={lead}
                     onUpdateLead={onUpdateLead}
                     scrollRef={idx === grouped[status].length - 1 ? scrollRef : null}
+                    socket={socket}
                   />
                 ))}
               </Tbody>


### PR DESCRIPTION
## Summary
- remove direct socket.io client creation in LeadCard
- pass shared socket from App through LeadList to LeadCard
- clean up transcript listener using stored handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 98 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1245b6d48327874adb9ffcef3cc1