### PR TITLE
Implement optional scrolling via ref in LeadCard

### DIFF
--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -24,7 +24,7 @@ function SoundWave() {
   );
 }
 
-export default function LeadCard({ lead, onUpdateLead, socket }) {
+export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
   const toast = useToast();
   const reportRef = useRef();
   const pollingRef = useRef(null);
@@ -39,6 +39,12 @@ export default function LeadCard({ lead, onUpdateLead, socket }) {
   const cardBg = useColorModeValue("white", "gray.700");
   const modalBg = useColorModeValue("white", "gray.800");
   const textColor = useColorModeValue("gray.800", "gray.100");
+
+  useEffect(() => {
+    if (scrollRef?.current) {
+      scrollRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [scrollRef]);
 
   const checkCallStatus = async () => {
     try {
@@ -137,6 +143,7 @@ export default function LeadCard({ lead, onUpdateLead, socket }) {
         </CardBody>
       </Card> */}
       <Tr
+        ref={scrollRef}
         onClick={openReport}
         _hover={{ bg: useColorModeValue("gray.50", "gray.700"), cursor: "pointer" }}
         transition="all 0.2s ease"

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -86,15 +86,18 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All
                 </Tr>
               </Thead>
               <Tbody>
-                {grouped[status].map((lead, idx) => (
-                  <LeadCard
-                    key={lead.id}
-                    lead={lead}
-                    onUpdateLead={onUpdateLead}
-                    scrollRef={idx === grouped[status].length - 1 ? scrollRef : null}
-                    socket={socket}
-                  />
-                ))}
+                {grouped[status].map((lead, idx) => {
+                  const isLast = idx === grouped[status].length - 1;
+                  return (
+                    <LeadCard
+                      key={lead.id}
+                      lead={lead}
+                      onUpdateLead={onUpdateLead}
+                      scrollRef={isLast ? scrollRef : undefined}
+                      socket={socket}
+                    />
+                  );
+                })}
               </Tbody>
             </Table>
           </Box>


### PR DESCRIPTION
## Summary
- Scroll LeadCard into view when a reference is provided
- Pass scroll ref only to the final LeadCard in LeadList

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 102 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1391d4648327bf9638510770d387