### PR TITLE
Use __dirname to resolve lead data path

### DIFF
--- a/server/services/leadDataService.js
+++ b/server/services/leadDataService.js
@@ -4,9 +4,8 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-// const leadsFile = path.join(__dirname, '../data/leads.json');
 
-const leadsFile = path.join(process.cwd(), 'data/leads.json');
+const leadsFile = path.join(__dirname, '../data/leads.json');
 
 export async function getLeadById(id = null, phone = null) {
   const leads = JSON.parse(fs.readFileSync(leadsFile, 'utf-8'));


### PR DESCRIPTION
## Summary
- Resolve leads.json path relative to the service's directory
- Remove outdated commented path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf14e7c650832781a8051ddd76e997