### PR TITLE
Reset isCalling after failed calls

### DIFF
--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -89,6 +89,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
       setCallStatus("✅ Call initiated");
     } catch (err) {
       setCallStatus("❌ Failed to connect");
+      setIsCalling(false);
     } finally {
       openCall();
     }
@@ -187,6 +188,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
               startCall(e);
             }}
             mr={2}
+            isLoading={isCalling}
           >
             📞 Call
           </Button>


### PR DESCRIPTION
## Summary
- Stop `isCalling` when a call fails
- Show loading state on the call button

## Testing
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` *(fails: 106 problems (102 errors, 4 warnings))*
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf157456e883279246578fbb27485b