### PR TITLE
Use server base URL for Twilio callbacks

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -28,6 +28,19 @@ node server.js
 The server will start on:
 📡 http://localhost:3000
 
+🛠️ Environment Variables
+
+Create a `.env` file (or configure your deployment environment) with the following variables before starting the server:
+
+```
+TWILIO_SID=<your Twilio account SID>
+TWILIO_AUTH=<your Twilio auth token>
+TWILIO_PHONE=<your Twilio phone number>
+SERVER_BASE_URL=<public base URL of this server>
+```
+
+`SERVER_BASE_URL` is used to construct webhook URLs (e.g., Twilio voice and status callbacks).
+
 🔌 API Endpoints
 GET /api/leads
 Retrieve all existing leads.

--- a/server/services/twilioService.js
+++ b/server/services/twilioService.js
@@ -7,17 +7,15 @@ dotenv.config();
 const accountSid = process.env.TWILIO_SID;
 const authToken = process.env.TWILIO_AUTH;
 const twilioNumber = process.env.TWILIO_PHONE;
-
-console.log('🧪 TWILIO_ACCOUNT_SID:', accountSid);
-console.log('🧪 TWILIO_PHONE:', twilioNumber);
+const serverBaseUrl = process.env.SERVER_BASE_URL;
 
 const client = twilio(accountSid, authToken);
 
 export const initiateCall = async (phoneNumber, leadId) => {
   console.log("📞 initiateCall →", phoneNumber, leadId);
 
-  const voiceUrl = `https://dbcc434f8aa7.ngrok-free.app/api/phone/voice?leadId=${encodeURIComponent(leadId)}`;
-  const statusCallbackUrl = `https://dbcc434f8aa7.ngrok-free.app/api/phone/status-callback`;
+  const voiceUrl = `${serverBaseUrl}/api/phone/voice?leadId=${encodeURIComponent(leadId)}`;
+  const statusCallbackUrl = `${serverBaseUrl}/api/phone/status-callback`;
 
   const call = await client.calls.create({
     to: phoneNumber,


### PR DESCRIPTION
## Summary
- Remove debug logs for Twilio credentials
- Parameterize voice and status callback URLs using `SERVER_BASE_URL`
- Document required Twilio environment variables and base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf18efa1b08327bce6011b7741f41f