### PR TITLE
feat: add custom chakra theme

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,10 +3,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { ChakraProvider } from '@chakra-ui/react'
 import App from './App.jsx'
+import theme from './theme/index.js'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <App />
     </ChakraProvider>
   </React.StrictMode>

--- a/client/src/theme/index.js
+++ b/client/src/theme/index.js
@@ -1,0 +1,40 @@
+import { extendTheme } from '@chakra-ui/react'
+
+const theme = extendTheme({
+  colors: {
+    brand: {
+      50: '#f5faff',
+      100: '#e0eaff',
+      200: '#b3ccff',
+      300: '#80aaff',
+      400: '#4d88ff',
+      500: '#1a66ff',
+      600: '#004de6',
+      700: '#0038b4',
+      800: '#002282',
+      900: '#000c51',
+    },
+  },
+  fonts: {
+    heading: 'Inter, sans-serif',
+    body: 'Inter, sans-serif',
+  },
+  components: {
+    Button: {
+      baseStyle: {
+        borderRadius: 'md',
+      },
+      variants: {
+        solid: {
+          bg: 'brand.500',
+          color: 'white',
+          _hover: {
+            bg: 'brand.600',
+          },
+        },
+      },
+    },
+  },
+})
+
+export default theme


### PR DESCRIPTION
## Summary
- add reusable Chakra UI theme with brand palette, fonts and button overrides
- wire theme into ChakraProvider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 102 errors)


------
https://chatgpt.com/codex/tasks/task_e_68bf1b3d261c832784291f78a429b376