### PR TITLE
feat: replace emojis with icons

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,18 @@ import {
   SimpleGrid, Tooltip as ChakraTooltip
 } from "@chakra-ui/react";
 import { AddIcon, MinusIcon, MoonIcon, SunIcon } from "@chakra-ui/icons";
+import { Icon } from "@chakra-ui/react";
+import {
+  FiBarChart2,
+  FiFileText,
+  FiSettings,
+  FiList,
+  FiCheckCircle,
+  FiPhoneCall,
+  FiCalendar,
+  FiXCircle,
+  FiStar
+} from "react-icons/fi";
 import { useEffect, useRef, useState } from "react";
 import { io } from "socket.io-client";
 import LeadForm from "./components/LeadForm";
@@ -87,11 +99,19 @@ function App() {
       <Flex justify="space-between" align="center" px={8} py={4} bg={useColorModeValue("white", "gray.900")} borderBottom="1px solid" borderColor={borderColor} shadow="sm">
         <Image src="/public/faviLogo.png" alt="Logo" h="36px" />
         <HStack spacing={2}>
-          {["dashboard", "reports", "settings"].map(view => (
-            <Button key={view} size="sm" variant="ghost" onClick={() => setModalView(view)}>
-              {view === "dashboard" && "📊 Dashboard"}
-              {view === "reports" && "📋 Reports"}
-              {view === "settings" && "⚙️ Settings"}
+          {[
+            { view: "dashboard", label: "Dashboard", icon: FiBarChart2 },
+            { view: "reports", label: "Reports", icon: FiFileText },
+            { view: "settings", label: "Settings", icon: FiSettings }
+          ].map(({ view, label, icon }) => (
+            <Button
+              key={view}
+              size="sm"
+              variant="ghost"
+              leftIcon={<Icon as={icon} aria-label={label} />}
+              onClick={() => setModalView(view)}
+            >
+              {label}
             </Button>
           ))}
           <ChakraTooltip label={colorMode === "light" ? "Dark Mode" : "Light Mode"}>
@@ -103,20 +123,23 @@ function App() {
       <Container maxW="7xl" py={10}>
         {/* FILTERS */}
         <HStack spacing={3} mb={8} justify="center" wrap="wrap">
-          {["All", "Qualified", "Answered", "Scheduled", "Unqualified", "New"].map(status => (
+          {[
+            { status: "All", label: "All", icon: FiList },
+            { status: "Qualified", label: "Qualified", icon: FiCheckCircle },
+            { status: "Answered", label: "Answered", icon: FiPhoneCall },
+            { status: "Scheduled", label: "Scheduled", icon: FiCalendar },
+            { status: "Unqualified", label: "Unqualified", icon: FiXCircle },
+            { status: "New", label: "New", icon: FiStar }
+          ].map(({ status, label, icon }) => (
             <Button
               key={status}
               size="sm"
               colorScheme={filter === status ? "orange" : "gray"}
               variant={filter === status ? "solid" : "outline"}
               onClick={() => setFilter(status)}
+              leftIcon={<Icon as={icon} aria-label={label} />}
             >
-              {status === "All" && "📋 All"}
-              {status === "Qualified" && "✅ Qualified"}
-              {status === "Answered" && "🟡 Answered"}
-              {status === "Scheduled" && "📅 Scheduled"}
-              {status === "Unqualified" && "❌ Unqualified"}
-              {status === "New" && "🆕 New"}
+              {label}
             </Button>
           ))}
         </HStack>

--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -3,8 +3,10 @@ import {
   Modal, ModalOverlay, ModalContent, ModalHeader,
   ModalBody, ModalFooter, useDisclosure, useColorModeValue,
   VStack, Button, IconButton, Avatar, useToast, Divider,Tr, Td,
+  HStack, Icon
 } from '@chakra-ui/react';
 import { PhoneIcon, CloseIcon } from '@chakra-ui/icons';
+import { FiFileText, FiUser, FiPhone } from 'react-icons/fi';
 import { useRef, useEffect, useState } from 'react';
 import html2pdf from 'html2pdf.js';
 
@@ -150,11 +152,17 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
         transition="all 0.2s ease"
       >
         <Td fontWeight="medium">
-          🧍 <strong>{lead.firstName} {lead.lastName}</strong>
+          <HStack>
+            <Icon as={FiUser} aria-label="Name" />
+            <Text as="span" fontWeight="bold">{lead.firstName} {lead.lastName}</Text>
+          </HStack>
         </Td>
 
         <Td color="gray.600" fontSize="sm">
-          📞 <span>{lead.phone}</span>
+          <HStack>
+            <Icon as={FiPhone} aria-label="Phone" />
+            <Text as="span">{lead.phone}</Text>
+          </HStack>
         </Td>
 
         <Td>
@@ -189,8 +197,9 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
             }}
             mr={2}
             isLoading={isCalling}
+            leftIcon={<PhoneIcon />}
           >
-            📞 Call
+            Call
           </Button>
           <Button
             size="sm"
@@ -199,8 +208,9 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
               e.stopPropagation();
               openReport();
             }}
+            leftIcon={<Icon as={FiFileText} />}
           >
-            📄 View Report
+            View Report
           </Button>
         </Td>
       </Tr>
@@ -209,7 +219,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
         <ModalOverlay />
         <ModalContent borderRadius="2xl" bg={modalBg} p={6} position="relative">
           <IconButton icon={<CloseIcon />} position="absolute" top={2} right={2} size="sm"
-            variant="ghost" onClick={closeCall} />
+            variant="ghost" onClick={closeCall} aria-label="Close call" />
           <ModalHeader textAlign="center" fontSize="lg" fontWeight="bold" color={textColor}>
             📞 Calling {lead.firstName}
           </ModalHeader>

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -11,14 +11,26 @@ import {
   Tr,
   Th,
   Box,
+  HStack,
+  Icon
 } from "@chakra-ui/react";
+import {
+  FiCheckCircle,
+  FiPhoneCall,
+  FiXCircle,
+  FiStar,
+  FiTag,
+  FiUser,
+  FiPhone,
+  FiMoreHorizontal
+} from "react-icons/fi";
 import LeadCard from "./LeadCard";
 
-const STATUS_LABELS = {
-  Qualified: "✅ Qualified",
-  Answered: "🟡 Answered",
-  Unqualified: "❌ Unqualified",
-  New: "🆕 New",
+const STATUS_ICONS = {
+  Qualified: FiCheckCircle,
+  Answered: FiPhoneCall,
+  Unqualified: FiXCircle,
+  New: FiStar,
 };
 
 export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All", socket }) {
@@ -73,16 +85,39 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All
               borderColor="orange.300"
               pl={3}
             >
-              {STATUS_LABELS[status] || `🔖 ${status}`}
+              <HStack>
+                <Icon as={STATUS_ICONS[status] || FiTag} aria-label={`${status} leads`} />
+                <Text>{status}</Text>
+              </HStack>
             </Heading>
 
             <Table variant="simple" size="sm">
               <Thead bg={headerBg}>
                 <Tr>
-                  <Th>👤 Name</Th>
-                  <Th>📞 Phone</Th>
-                  <Th>Status</Th>
-                  <Th>Actions</Th>
+                  <Th>
+                    <HStack>
+                      <Icon as={FiUser} aria-label="Name" />
+                      <Text>Name</Text>
+                    </HStack>
+                  </Th>
+                  <Th>
+                    <HStack>
+                      <Icon as={FiPhone} aria-label="Phone" />
+                      <Text>Phone</Text>
+                    </HStack>
+                  </Th>
+                  <Th>
+                    <HStack>
+                      <Icon as={FiTag} aria-label="Status" />
+                      <Text>Status</Text>
+                    </HStack>
+                  </Th>
+                  <Th>
+                    <HStack>
+                      <Icon as={FiMoreHorizontal} aria-label="Actions" />
+                      <Text>Actions</Text>
+                    </HStack>
+                  </Th>
                 </Tr>
               </Thead>
               <Tbody>


### PR DESCRIPTION
## Summary
- swap emoji navigation and filters for React icon components
- render LeadList headers with icons for name, phone, status and actions
- update LeadCard actions to use consistent icons and aria labels

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 101 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1b3ecc348327a3152328e6f56eb5