### PR TITLE
Resolve merge conflicts for card layout

### DIFF
--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -2,11 +2,10 @@ import {
   Card, CardBody, Heading, Text, Stack, Box, Badge,
   Modal, ModalOverlay, ModalContent, ModalHeader,
   ModalBody, ModalFooter, useDisclosure, useColorModeValue,
-  VStack, Button, IconButton, Avatar, useToast, Divider,Tr, Td,
-  HStack, Icon
+  VStack, Button, IconButton, Avatar, Divider
 } from '@chakra-ui/react';
 import { PhoneIcon, CloseIcon } from '@chakra-ui/icons';
-import { FiFileText, FiUser, FiPhone } from 'react-icons/fi';
+import { FiFileText } from 'react-icons/fi';
 import { useRef, useEffect, useState } from 'react';
 import html2pdf from 'html2pdf.js';
 
@@ -27,7 +26,6 @@ function SoundWave() {
 }
 
 export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
-  const toast = useToast();
   const reportRef = useRef();
   const pollingRef = useRef(null);
 
@@ -122,9 +120,18 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
 
   return (
     <>
-      {/* <Card bg={cardBg} border="1px solid" borderColor={useColorModeValue("gray.200", "gray.600")}
-        borderRadius="xl" boxShadow="sm" _hover={{ shadow: "lg", transform: "scale(1.01)" }}
-        transition="all 0.2s ease" cursor="pointer" onClick={openReport}>
+      <Card
+        ref={scrollRef}
+        bg={cardBg}
+        border="1px solid"
+        borderColor={useColorModeValue("gray.200", "gray.600")}
+        borderRadius="xl"
+        boxShadow="sm"
+        _hover={{ shadow: "lg", transform: "scale(1.01)" }}
+        transition="all 0.2s ease"
+        cursor="pointer"
+        onClick={openReport}
+      >
         <CardBody>
           <Stack spacing={2} fontSize="sm">
             <Heading size="sm" noOfLines={1} color={textColor}>
@@ -135,85 +142,30 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
               {lead.status}
             </Badge>
             <Stack direction="row" spacing={2} mt={3}>
-              <Button size="xs" variant="outline" leftIcon={<PhoneIcon />} onClick={startCall} isLoading={isCalling}>
+              <Button
+                size="xs"
+                variant="outline"
+                leftIcon={<PhoneIcon />}
+                onClick={startCall}
+                isLoading={isCalling}
+              >
                 Call
               </Button>
-              <Button size="xs" colorScheme="blue" onClick={(e) => { e.stopPropagation(); openReport(); }}>
+              <Button
+                size="xs"
+                colorScheme="blue"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openReport();
+                }}
+                leftIcon={<FiFileText />}
+              >
                 View Report
               </Button>
             </Stack>
           </Stack>
         </CardBody>
-      </Card> */}
-      <Tr
-        ref={scrollRef}
-        onClick={openReport}
-        _hover={{ bg: useColorModeValue("gray.50", "gray.700"), cursor: "pointer" }}
-        transition="all 0.2s ease"
-      >
-        <Td fontWeight="medium">
-          <HStack>
-            <Icon as={FiUser} aria-label="Name" />
-            <Text as="span" fontWeight="bold">{lead.firstName} {lead.lastName}</Text>
-          </HStack>
-        </Td>
-
-        <Td color="gray.600" fontSize="sm">
-          <HStack>
-            <Icon as={FiPhone} aria-label="Phone" />
-            <Text as="span">{lead.phone}</Text>
-          </HStack>
-        </Td>
-
-        <Td>
-          <Badge
-            colorScheme={
-              lead.status === "Qualified"
-                ? "green"
-                : lead.status === "Unqualified"
-                ? "red"
-                : lead.status === "Answered"
-                ? "yellow"
-                : "gray"
-            }
-            variant="subtle"
-            fontSize="0.75em"
-            px={3}
-            py={1}
-            borderRadius="md"
-          >
-            {lead.status?.toUpperCase()}
-          </Badge>
-        </Td>
-
-        <Td>
-          <Button
-            size="sm"
-            variant="outline"
-            colorScheme="teal"
-            onClick={(e) => {
-              e.stopPropagation();
-              startCall(e);
-            }}
-            mr={2}
-            isLoading={isCalling}
-            leftIcon={<PhoneIcon />}
-          >
-            Call
-          </Button>
-          <Button
-            size="sm"
-            colorScheme="blue"
-            onClick={(e) => {
-              e.stopPropagation();
-              openReport();
-            }}
-            leftIcon={<Icon as={FiFileText} />}
-          >
-            View Report
-          </Button>
-        </Td>
-      </Tr>
+      </Card>
 
       <Modal isOpen={isCallOpen} onClose={closeCall} size="md" isCentered>
         <ModalOverlay />

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -1,16 +1,12 @@
-// LeadList.jsx (Modern Professional Table List View)
+// LeadList.jsx (Modern Professional Card Grid View)
 import {
   Text,
   Center,
   Stack,
   Heading,
   useColorModeValue,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
   Box,
+  SimpleGrid,
   HStack,
   Icon
 } from "@chakra-ui/react";
@@ -19,10 +15,7 @@ import {
   FiPhoneCall,
   FiXCircle,
   FiStar,
-  FiTag,
-  FiUser,
-  FiPhone,
-  FiMoreHorizontal
+  FiTag
 } from "react-icons/fi";
 import LeadCard from "./LeadCard";
 
@@ -34,9 +27,6 @@ const STATUS_ICONS = {
 };
 
 export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All", socket }) {
-  const borderColor = useColorModeValue("gray.200", "gray.700");
-  const headerBg = useColorModeValue("gray.100", "gray.700");
-
   const grouped = leads.reduce((acc, lead) => {
     const status = (lead.status || "New").trim();
     if (!acc[status]) acc[status] = [];
@@ -91,50 +81,20 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All
               </HStack>
             </Heading>
 
-            <Table variant="simple" size="sm">
-              <Thead bg={headerBg}>
-                <Tr>
-                  <Th>
-                    <HStack>
-                      <Icon as={FiUser} aria-label="Name" />
-                      <Text>Name</Text>
-                    </HStack>
-                  </Th>
-                  <Th>
-                    <HStack>
-                      <Icon as={FiPhone} aria-label="Phone" />
-                      <Text>Phone</Text>
-                    </HStack>
-                  </Th>
-                  <Th>
-                    <HStack>
-                      <Icon as={FiTag} aria-label="Status" />
-                      <Text>Status</Text>
-                    </HStack>
-                  </Th>
-                  <Th>
-                    <HStack>
-                      <Icon as={FiMoreHorizontal} aria-label="Actions" />
-                      <Text>Actions</Text>
-                    </HStack>
-                  </Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {grouped[status].map((lead, idx) => {
-                  const isLast = idx === grouped[status].length - 1;
-                  return (
-                    <LeadCard
-                      key={lead.id}
-                      lead={lead}
-                      onUpdateLead={onUpdateLead}
-                      scrollRef={isLast ? scrollRef : undefined}
-                      socket={socket}
-                    />
-                  );
-                })}
-              </Tbody>
-            </Table>
+            <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
+              {grouped[status].map((lead, idx) => {
+                const isLast = idx === grouped[status].length - 1;
+                return (
+                  <LeadCard
+                    key={lead.id}
+                    lead={lead}
+                    onUpdateLead={onUpdateLead}
+                    scrollRef={isLast ? scrollRef : undefined}
+                    socket={socket}
+                  />
+                );
+              })}
+            </SimpleGrid>
           </Box>
         ) : null
       ))}


### PR DESCRIPTION
## Summary
- switch lead list to a SimpleGrid card layout grouped by status
- restore LeadCard to card design with consistent Call and View Report actions

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1e9726cc83278aa285fba6722d18