### PR TITLE
Add webhook endpoint for external lead submissions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -76,6 +76,29 @@ Edit
   "lastName": "Smith",
   "phone": "987-654-3210"
 }
+
+POST /api/leads/webhook
+Receive new lead data from external providers.
+
+Request Body:
+
+```json
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "phone": "+15551234567",
+  "address": {
+    "street": "123 Main St",
+    "city": "Springfield",
+    "state": "CA",
+    "zip": "90210"
+  },
+  "note": "Optional note about the lead"
+}
+```
+
+All fields are required except `note`.
+
 PUT /api/leads/:id
 Update an existing lead (notes, status, responses, etc.).
 

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import { addLead } from '../controllers/leadController.js';
+
+const router = express.Router();
+
+router.post('/', (req, res) => {
+  const { firstName, lastName, phone, address, note } = req.body;
+
+  if (
+    typeof firstName !== 'string' ||
+    typeof lastName !== 'string' ||
+    typeof phone !== 'string' ||
+    typeof address !== 'object' ||
+    typeof address.street !== 'string' ||
+    typeof address.city !== 'string' ||
+    typeof address.state !== 'string' ||
+    typeof address.zip !== 'string' ||
+    (note !== undefined && typeof note !== 'string')
+  ) {
+    return res.status(400).json({ error: 'Invalid lead payload' });
+  }
+
+  return addLead(req, res);
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ import leadsRoutes from './routes/leads.js';
 import actionsRoutes from './routes/actions.js';
 import phoneRoutes from './routes/phoneRoutes.js';
 import simulationRoutes from './routes/simulationRoutes.js';
+import webhookRoutes from './routes/webhook.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -37,6 +38,7 @@ app.use(express.urlencoded({ extended: true })); // Parses application/x-www-for
 app.set('io', io);
 
 // ✅ Routes
+app.use('/api/leads/webhook', webhookRoutes);
 app.use('/api/leads', leadsRoutes);
 app.use('/api/actions', actionsRoutes);
 app.use('/api/phone', phoneRoutes);


### PR DESCRIPTION
## Summary
- add `/api/leads/webhook` for external lead data
- validate inbound lead payload and reuse existing `addLead` logic
- document webhook payload schema for integrators

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2336733483279ccfcc2d16573958