### PR TITLE
Add CSV upload option for leads

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -142,6 +142,15 @@ POST /api/leads → Add a new lead
 
 PUT /api/leads/:id → Update lead with answers, notes, or status
 
+📥 CSV Upload Format
+You can bulk upload leads via a CSV file. Ensure the first row contains these headers:
+
+```
+firstName,lastName,phone,street,city,state,zip,note
+```
+
+Each subsequent row should provide the lead's details. The `note` column is optional.
+
 ✅ What’s Ready
 Fully functioning UI to manage, qualify, and report on leads
 

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "framer-motion": "^10.18.0",
     "html2pdf.js": "^0.10.3",
+    "papaparse": "^5.4.1",
     "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ import { io } from "socket.io-client";
 import LeadForm from "./components/LeadForm";
 import LeadList from "./components/LeadList";
 import LeadSummary from "./components/LeadSummary";
+import LeadCsvUpload from "./components/LeadCsvUpload";
 
 import {
   ResponsiveContainer, PieChart, Pie, Cell, Tooltip as RechartsTooltip,
@@ -153,7 +154,12 @@ function App() {
             </VStack>
             <IconButton icon={showForm ? <MinusIcon /> : <AddIcon />} size="sm" onClick={() => setShowForm(!showForm)} />
           </Stack>
-          <Collapse in={showForm}><LeadForm onNewLead={addLead} /></Collapse>
+          <Collapse in={showForm}>
+            <Stack spacing={8}>
+              <LeadForm onNewLead={addLead} />
+              <LeadCsvUpload onNewLead={addLead} />
+            </Stack>
+          </Collapse>
         </Box>
 
         {/* LEADS */}

--- a/client/src/components/LeadCsvUpload.jsx
+++ b/client/src/components/LeadCsvUpload.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Input, Button, Stack, useToast } from '@chakra-ui/react';
+import Papa from 'papaparse';
+import PropTypes from 'prop-types';
+
+export default function LeadCsvUpload({ onNewLead }) {
+  const [file, setFile] = useState(null);
+  const toast = useToast();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!file) {
+      toast({
+        title: 'No file selected',
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    Papa.parse(file, {
+      header: true,
+      complete: async (results) => {
+        let success = 0;
+        let errors = 0;
+
+        for (const row of results.data) {
+          if (Object.values(row).every((val) => val === undefined || val === '')) continue;
+
+          const lead = {
+            firstName: row.firstName,
+            lastName: row.lastName,
+            phone: row.phone,
+            address: {
+              street: row.street,
+              city: row.city,
+              state: row.state,
+              zip: row.zip,
+            },
+            note: row.note,
+          };
+
+          try {
+            const res = await fetch('http://localhost:3000/api/leads', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(lead),
+            });
+            const data = await res.json();
+            if (data.success) {
+              success += 1;
+              if (onNewLead) onNewLead(data.lead);
+            } else {
+              errors += 1;
+            }
+          } catch (err) {
+            errors += 1;
+          }
+        }
+
+        toast({
+          title: 'CSV Upload Complete',
+          description: `${success} leads added${errors ? `, ${errors} failed` : ''}.`,
+          status: errors ? 'warning' : 'success',
+          duration: 5000,
+          isClosable: true,
+        });
+        setFile(null);
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack direction={{ base: 'column', md: 'row' }} spacing={4}>
+        <Input type="file" accept=".csv" onChange={(e) => setFile(e.target.files[0])} />
+        <Button type="submit" colorScheme="green">
+          Upload CSV
+        </Button>
+      </Stack>
+    </form>
+  );
+}
+
+LeadCsvUpload.propTypes = {
+  onNewLead: PropTypes.func,
+};


### PR DESCRIPTION
## Summary
- add papaparse dependency for CSV parsing
- create `LeadCsvUpload` component to parse CSV files and send leads to API
- render CSV uploader alongside existing lead form and document required headers

## Testing
- `npm install papaparse` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 95 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bf266a0f9c8327a72b44219962f131