### PR TITLE
Add configurable auto-call scheduler with UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,6 +24,7 @@ import LeadForm from "./components/LeadForm";
 import LeadList from "./components/LeadList";
 import LeadSummary from "./components/LeadSummary";
 import LeadCsvUpload from "./components/LeadCsvUpload";
+import AutoCallMenu from "./components/AutoCallMenu";
 
 import {
   ResponsiveContainer, PieChart, Pie, Cell, Tooltip as RechartsTooltip,
@@ -56,6 +57,13 @@ function App() {
   const [showLeads, setShowLeads] = useState(() => localStorage.getItem("showLeads") !== "false");
   const [filter, setFilter] = useState(() => localStorage.getItem("leadFilter") || "All");
   const [modalView, setModalView] = useState(null);
+
+  const navItems = [
+    { view: "dashboard", label: "Dashboard", icon: FiBarChart2 },
+    { view: "reports", label: "Reports", icon: FiFileText },
+    { view: "settings", label: "Settings", icon: FiSettings },
+    { view: "autoCall", label: "Auto Call Settings", icon: FiPhoneCall }
+  ];
 
   useEffect(() => {
     const socket = io('http://localhost:3000', { transports: ['websocket'] });
@@ -100,11 +108,7 @@ function App() {
       <Flex justify="space-between" align="center" px={8} py={4} bg={useColorModeValue("white", "gray.900")} borderBottom="1px solid" borderColor={borderColor} shadow="sm">
         <Image src="/public/faviLogo.png" alt="Logo" h="36px" />
         <HStack spacing={2}>
-          {[
-            { view: "dashboard", label: "Dashboard", icon: FiBarChart2 },
-            { view: "reports", label: "Reports", icon: FiFileText },
-            { view: "settings", label: "Settings", icon: FiSettings }
-          ].map(({ view, label, icon }) => (
+          {navItems.map(({ view, label, icon }) => (
             <Button
               key={view}
               size="sm"
@@ -227,7 +231,9 @@ function App() {
         <Modal isOpen onClose={() => setModalView(null)} size="6xl" isCentered>
           <ModalOverlay />
           <ModalContent borderRadius="xl" p={{ base: 4, md: 8 }} bg={useColorModeValue("white", "gray.900")} shadow="xl" maxH="90vh" overflowY="auto">
-            <ModalHeader textTransform="capitalize" fontSize="2xl">{modalView}</ModalHeader>
+            <ModalHeader textTransform="capitalize" fontSize="2xl">
+              {navItems.find(item => item.view === modalView)?.label || modalView}
+            </ModalHeader>
             <ModalCloseButton />
             <ModalBody pt={6}>
               {modalView === "reports" ? (
@@ -240,6 +246,8 @@ function App() {
                 <Box textAlign="center">
                   <Text fontSize="lg" fontWeight="medium">⚙️ Settings</Text>
                 </Box>
+              ) : modalView === "autoCall" ? (
+                <AutoCallMenu />
               ) : (
                 <Text>This is the <strong>{modalView}</strong> section.</Text>
               )}

--- a/client/src/components/AutoCallMenu.jsx
+++ b/client/src/components/AutoCallMenu.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  NumberInput,
+  NumberInputField,
+  VStack,
+  Alert,
+  AlertIcon
+} from '@chakra-ui/react';
+
+export default function AutoCallMenu() {
+  const [config, setConfig] = useState({ startTime: '', stopTime: '', callsPerHour: 1 });
+  const [message, setMessage] = useState(null);
+
+  const fetchConfig = async () => {
+    const res = await fetch('http://localhost:3000/api/scheduler/config');
+    const data = await res.json();
+    setConfig(data);
+  };
+
+  useEffect(() => {
+    fetchConfig();
+  }, []);
+
+  const handleChange = (e) => {
+    setConfig(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleCallsChange = (_, value) => {
+    setConfig(prev => ({ ...prev, callsPerHour: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage(null);
+    if (config.startTime >= config.stopTime) {
+      setMessage({ type: 'error', text: 'Start time must be before stop time' });
+      return;
+    }
+    if (config.callsPerHour <= 0) {
+      setMessage({ type: 'error', text: 'Calls per hour must be greater than 0' });
+      return;
+    }
+    try {
+      const res = await fetch('http://localhost:3000/api/scheduler/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          startTime: config.startTime,
+          stopTime: config.stopTime,
+          callsPerHour: Number(config.callsPerHour)
+        })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      await fetchConfig();
+      setMessage({ type: 'success', text: 'Settings saved' });
+    } catch (err) {
+      setMessage({ type: 'error', text: 'Failed to save settings' });
+    }
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} maxW="md" mx="auto">
+      <VStack spacing={4} align="stretch">
+        <FormControl>
+          <FormLabel>Start Time</FormLabel>
+          <Input type="time" name="startTime" value={config.startTime} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Stop Time</FormLabel>
+          <Input type="time" name="stopTime" value={config.stopTime} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Calls Per Hour</FormLabel>
+          <NumberInput min={1} value={config.callsPerHour} onChange={handleCallsChange}>
+            <NumberInputField name="callsPerHour" />
+          </NumberInput>
+        </FormControl>
+        <Button type="submit" colorScheme="blue">Save</Button>
+        {message && (
+          <Alert status={message.type}>
+            <AlertIcon />
+            {message.text}
+          </Alert>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/server/data/scheduler.json
+++ b/server/data/scheduler.json
@@ -1,0 +1,5 @@
+{
+  "startTime": "09:00",
+  "stopTime": "17:00",
+  "callsPerHour": 60
+}

--- a/server/routes/schedulerRoutes.js
+++ b/server/routes/schedulerRoutes.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import { readSchedulerConfig, writeSchedulerConfig } from '../utils/schedulerUtils.js';
+
+const router = express.Router();
+
+router.get('/config', (req, res) => {
+  const config = readSchedulerConfig();
+  res.json(config);
+});
+
+router.put('/config', (req, res) => {
+  const { startTime, stopTime, callsPerHour } = req.body;
+  if (!startTime || !stopTime || typeof callsPerHour !== 'number') {
+    return res.status(400).json({ error: 'Invalid config' });
+  }
+  if (startTime >= stopTime) {
+    return res.status(400).json({ error: 'startTime must be before stopTime' });
+  }
+  if (callsPerHour <= 0) {
+    return res.status(400).json({ error: 'callsPerHour must be greater than 0' });
+  }
+  const config = { startTime, stopTime, callsPerHour };
+  writeSchedulerConfig(config);
+  res.json(config);
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,7 @@ import actionsRoutes from './routes/actions.js';
 import phoneRoutes from './routes/phoneRoutes.js';
 import simulationRoutes from './routes/simulationRoutes.js';
 import webhookRoutes from './routes/webhook.js';
+import schedulerRoutes from './routes/schedulerRoutes.js';
 import { startScheduler } from './services/callScheduler.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -44,6 +45,7 @@ app.use('/api/leads', leadsRoutes);
 app.use('/api/actions', actionsRoutes);
 app.use('/api/phone', phoneRoutes);
 app.use('/api/simulation', simulationRoutes);
+app.use('/api/scheduler', schedulerRoutes);
 
 // ✅ Start scheduled jobs
 startScheduler();

--- a/server/services/callScheduler.js
+++ b/server/services/callScheduler.js
@@ -1,27 +1,47 @@
 import cron from 'node-cron';
 import { readLeads, updateLeadById } from '../utils/leadUtils.js';
+import { readSchedulerConfig } from '../utils/schedulerUtils.js';
 import { initiateCall } from './twilioService.js';
 
 /**
  * Starts a cron job that checks for leads needing follow-up calls.
  * Runs every minute and initiates calls for overdue follow-ups.
  */
+let availableCalls = 0;
+
 export function startScheduler() {
   // Run job every minute
   cron.schedule('* * * * *', async () => {
-    const leads = readLeads();
+    const config = readSchedulerConfig();
+    const { startTime, stopTime, callsPerHour } = config;
     const now = new Date();
+
+    const [startHour, startMinute] = startTime.split(':').map(Number);
+    const [stopHour, stopMinute] = stopTime.split(':').map(Number);
+    const start = new Date(now);
+    start.setHours(startHour, startMinute, 0, 0);
+    const stop = new Date(now);
+    stop.setHours(stopHour, stopMinute, 0, 0);
+
+    if (now < start || now > stop) return;
+
+    availableCalls += callsPerHour / 60;
+    let callsRemaining = Math.floor(availableCalls);
+    if (callsRemaining <= 0) return;
+
+    const leads = readLeads();
 
     for (const lead of leads) {
       if (!lead.followUpDate) continue;
 
       const followUpTime = new Date(lead.followUpDate);
 
-      if (followUpTime <= now && !lead.callInProgress) {
+      if (followUpTime <= now && !lead.callInProgress && callsRemaining > 0) {
         try {
           await initiateCall(lead.phone, lead.id);
-          // Prevent repeated calls for the same follow-up
           updateLeadById(lead.id, { callInProgress: true, followUpDate: null });
+          callsRemaining--;
+          availableCalls--;
         } catch (err) {
           console.error('Failed to initiate scheduled call:', err);
         }

--- a/server/utils/schedulerUtils.js
+++ b/server/utils/schedulerUtils.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const configFile = path.join(__dirname, '../data/scheduler.json');
+
+export function readSchedulerConfig() {
+  if (!fs.existsSync(configFile)) {
+    return { startTime: '09:00', stopTime: '17:00', callsPerHour: 60 };
+  }
+  const data = fs.readFileSync(configFile, 'utf-8');
+  return JSON.parse(data);
+}
+
+export function writeSchedulerConfig(config) {
+  fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+}


### PR DESCRIPTION
## Summary
- persist auto-call scheduler settings in server-side JSON and helper utils
- expose REST API to read and update scheduler configuration
- enforce schedule and rate limits in call scheduler and add client UI to manage settings

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: many lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf31c07f788327911ab2ba4631d489