### PR TITLE
Add authentication and protect API routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -25,6 +25,7 @@ import LeadList from "./components/LeadList";
 import LeadSummary from "./components/LeadSummary";
 import LeadCsvUpload from "./components/LeadCsvUpload";
 import AutoCallMenu from "./components/AutoCallMenu";
+import PropTypes from 'prop-types';
 
 import {
   ResponsiveContainer, PieChart, Pie, Cell, Tooltip as RechartsTooltip,
@@ -42,7 +43,7 @@ function getStatusData(leads) {
   return Object.entries(grouped).map(([status, count]) => ({ name: status, value: count }));
 }
 
-function App() {
+function App({ onLogout }) {
   const { colorMode, toggleColorMode } = useColorMode();
   const formRef = useRef(null);
   const socketRef = useRef(null);
@@ -80,7 +81,9 @@ function App() {
   }, []);
 
   useEffect(() => {
-    fetch("http://localhost:3000/api/leads").then(res => res.json()).then(setLeads);
+    fetch("http://localhost:3000/api/leads", {
+      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+    }).then(res => res.json()).then(setLeads);
   }, []);
 
   useEffect(() => {
@@ -96,7 +99,10 @@ function App() {
   const updateLead = async (updated) => {
     await fetch(`http://localhost:3000/api/leads/${updated.id}`, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem('token')}`
+      },
       body: JSON.stringify(updated),
     });
     setLeads(prev => prev.map(l => l.id === updated.id ? updated : l));
@@ -108,20 +114,21 @@ function App() {
       <Flex justify="space-between" align="center" px={8} py={4} bg={useColorModeValue("white", "gray.900")} borderBottom="1px solid" borderColor={borderColor} shadow="sm">
         <Image src="/public/faviLogo.png" alt="Logo" h="36px" />
         <HStack spacing={2}>
-          {navItems.map(({ view, label, icon }) => (
-            <Button
-              key={view}
-              size="sm"
-              variant="ghost"
-              leftIcon={<Icon as={icon} aria-label={label} />}
-              onClick={() => setModalView(view)}
-            >
-              {label}
-            </Button>
-          ))}
-          <ChakraTooltip label={colorMode === "light" ? "Dark Mode" : "Light Mode"}>
+        {navItems.map(({ view, label, icon }) => (
+          <Button
+            key={view}
+            size="sm"
+            variant="ghost"
+            leftIcon={<Icon as={icon} aria-label={label} />}
+            onClick={() => setModalView(view)}
+          >
+            {label}
+          </Button>
+        ))}
+        <ChakraTooltip label={colorMode === "light" ? "Dark Mode" : "Light Mode"}>
             <IconButton size="sm" variant="ghost" onClick={toggleColorMode} icon={colorMode === "light" ? <MoonIcon /> : <SunIcon />} />
-          </ChakraTooltip>
+        </ChakraTooltip>
+        <Button size="sm" onClick={onLogout}>Logout</Button>
         </HStack>
       </Flex>
 
@@ -258,5 +265,9 @@ function App() {
     </Box>
   );
 }
+
+App.propTypes = {
+  onLogout: PropTypes.func.isRequired,
+};
 
 export default App;

--- a/client/src/components/AutoCallMenu.jsx
+++ b/client/src/components/AutoCallMenu.jsx
@@ -17,7 +17,9 @@ export default function AutoCallMenu() {
   const [message, setMessage] = useState(null);
 
   const fetchConfig = async () => {
-    const res = await fetch('http://localhost:3000/api/scheduler/config');
+    const res = await fetch('http://localhost:3000/api/scheduler/config', {
+      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+    });
     const data = await res.json();
     setConfig(data);
   };
@@ -48,7 +50,10 @@ export default function AutoCallMenu() {
     try {
       const res = await fetch('http://localhost:3000/api/scheduler/config', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
         body: JSON.stringify({
           startTime: config.startTime,
           stopTime: config.stopTime,

--- a/client/src/components/CallSession.jsx
+++ b/client/src/components/CallSession.jsx
@@ -48,7 +48,10 @@ export default function CallSession({ lead, onClose }) {
     try {
       const res = await fetch(`http://localhost:3000/api/leads/${lead.id}`, {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
         body: JSON.stringify(updatedLead),
       });
 

--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -57,7 +57,9 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
 
   const checkCallStatus = async () => {
     try {
-      const res = await fetch(`http://localhost:3000/api/leads/${lead.id}`);
+      const res = await fetch(`http://localhost:3000/api/leads/${lead.id}`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+      });
       const data = await res.json();
       if (!data.callInProgress) {
         clearInterval(pollingRef.current);
@@ -91,7 +93,10 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
     try {
       const res = await fetch("http://localhost:3000/api/phone/call", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem('token')}`
+        },
         body: JSON.stringify({ phoneNumber: lead.phone, leadId: lead.id })
       });
       if (!res.ok) throw new Error("Call failed");
@@ -108,7 +113,10 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
     try {
       const res = await fetch(`http://localhost:3000/api/leads/${lead.id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
         body: JSON.stringify({
           followUpDate: followUpDateInput
             ? new Date(followUpDateInput).toISOString()

--- a/client/src/components/LeadCsvUpload.jsx
+++ b/client/src/components/LeadCsvUpload.jsx
@@ -44,7 +44,10 @@ export default function LeadCsvUpload({ onNewLead }) {
           try {
             const res = await fetch('http://localhost:3000/api/leads', {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${localStorage.getItem('token')}`,
+              },
               body: JSON.stringify(lead),
             });
             const data = await res.json();

--- a/client/src/components/LeadForm.jsx
+++ b/client/src/components/LeadForm.jsx
@@ -60,7 +60,10 @@ export default function LeadForm({ onNewLead }) {
     try {
       const res = await fetch('http://localhost:3000/api/leads', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
         body: JSON.stringify(newLead),
       });
 

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Box, Button, FormControl, FormLabel, Heading, Input, VStack, useToast } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+
+export default function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const toast = useToast();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('http://localhost:3000/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      onLogin();
+    } catch (err) {
+      toast({ title: 'Login failed', status: 'error', duration: 3000, isClosable: true });
+    }
+  };
+
+  return (
+    <Box minH="100vh" display="flex" alignItems="center" justifyContent="center">
+      <Box as="form" onSubmit={handleSubmit} p={8} borderWidth="1px" borderRadius="lg" boxShadow="md">
+        <VStack spacing={4}>
+          <Heading size="md">Sign In</Heading>
+          <FormControl>
+            <FormLabel>Username</FormLabel>
+            <Input value={username} onChange={(e) => setUsername(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Password</FormLabel>
+            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          </FormControl>
+          <Button type="submit" colorScheme="blue" w="full">Login</Button>
+        </VStack>
+      </Box>
+    </Box>
+  );
+}
+
+Login.propTypes = {
+  onLogin: PropTypes.func.isRequired,
+};

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,14 +1,35 @@
 // main.jsx
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { ChakraProvider } from '@chakra-ui/react'
-import App from './App.jsx'
-import theme from './theme/index.js'
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import { ChakraProvider } from '@chakra-ui/react';
+import App from './App.jsx';
+import Login from './components/Login.jsx';
+import theme from './theme/index.js';
+
+function Root() {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const handleLogin = () => setToken(localStorage.getItem('token'));
+
+  const handleLogout = () => {
+    const t = localStorage.getItem('token');
+    if (t) {
+      fetch('http://localhost:3000/api/auth/logout', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${t}` },
+      }).catch(() => {});
+    }
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return token ? <App onLogout={handleLogout} /> : <Login onLogin={handleLogin} />;
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ChakraProvider theme={theme}>
-      <App />
+      <Root />
     </ChakraProvider>
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);

--- a/server/README.md
+++ b/server/README.md
@@ -37,11 +37,39 @@ TWILIO_SID=<your Twilio account SID>
 TWILIO_AUTH=<your Twilio auth token>
 TWILIO_PHONE=<your Twilio phone number>
 SERVER_BASE_URL=<public base URL of this server>
+ADMIN_USERNAME=<admin login name>
+ADMIN_PASSWORD_HASH=<sha256 hash of admin password>
 ```
 
 `SERVER_BASE_URL` is used to construct webhook URLs (e.g., Twilio voice and status callbacks).
 
+Generate `ADMIN_PASSWORD_HASH` with:
+
+```
+node -e "console.log(require('crypto').createHash('sha256').update('yourpassword').digest('hex'))"
+```
+
+All API routes (except `/api/auth/*` and `/api/leads/webhook`) require an `Authorization: Bearer <token>` header obtained via `POST /api/auth/login`.
+
 🔌 API Endpoints
+POST /api/auth/login
+Authenticate and receive a bearer token.
+
+Request Body:
+
+```json
+{ "username": "admin", "password": "secret" }
+```
+
+Response:
+
+```json
+{ "token": "..." }
+```
+
+POST /api/auth/logout
+Invalidate the current token. Requires `Authorization` header.
+
 GET /api/leads
 Retrieve all existing leads.
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,10 +1,16 @@
-export const requireAuth = (req, res, next) => {
-  const token = req.headers.authorization;
-  const expected = process.env.ADMIN_TOKEN;
+import crypto from 'crypto';
 
-  if (!token || token !== expected) {
+const activeTokens = new Set();
+
+export const generateToken = () => crypto.randomBytes(48).toString('hex');
+export const registerToken = (token) => activeTokens.add(token);
+export const unregisterToken = (token) => activeTokens.delete(token);
+
+export const requireAuth = (req, res, next) => {
+  const authHeader = req.headers.authorization || '';
+  const token = authHeader.split(' ')[1];
+  if (!token || !activeTokens.has(token)) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-
   next();
 };

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import crypto from 'crypto';
+import { generateToken, registerToken, unregisterToken } from '../middleware/auth.js';
+
+const router = express.Router();
+
+const hash = (str) => crypto.createHash('sha256').update(str).digest('hex');
+
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const storedUser = process.env.ADMIN_USERNAME;
+  const storedHash = process.env.ADMIN_PASSWORD_HASH;
+
+  if (!username || !password || username !== storedUser || hash(password) !== storedHash) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = generateToken();
+  registerToken(token);
+  res.json({ token });
+});
+
+router.post('/logout', (req, res) => {
+  const authHeader = req.headers.authorization || '';
+  const token = authHeader.split(' ')[1];
+  if (token) unregisterToken(token);
+  res.json({ success: true });
+});
+
+export default router;

--- a/server/routes/leads.js
+++ b/server/routes/leads.js
@@ -5,16 +5,17 @@ import {
   updateLead,
   getLeadById, // ← You need this
 } from '../controllers/leadController.js';
+import { requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.get('/', getLeads);
-router.post('/', addLead);
+router.get('/', requireAuth, getLeads);
+router.post('/', requireAuth, addLead);
 
 // ✅ Add this route
-router.get('/:id', getLeadById);
+router.get('/:id', requireAuth, getLeadById);
 
 // ✅ Make sure this route already exists
-router.put('/:id', updateLead);
+router.put('/:id', requireAuth, updateLead);
 
 export default router;

--- a/server/routes/phoneRoutes.js
+++ b/server/routes/phoneRoutes.js
@@ -3,16 +3,17 @@ import {
   startPhoneCall,
   continuePhoneCall,
   getVoiceScript,
-  handleCallStatus, 
+  handleCallStatus,
   receiveTranscript,
 } from '../controllers/phoneController.js';
 
 import { updateLeadById, readLeads } from '../utils/leadUtils.js';
+import { requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
 // 🔹 Route: Initiate call from frontend
-router.post('/call', express.json(), startPhoneCall);
+router.post('/call', requireAuth, express.json(), startPhoneCall);
 
 // 🔹 Route: Respond to Twilio 'Gather' action (keypress)
 router.post('/continue', express.urlencoded({ extended: false }), continuePhoneCall);

--- a/server/routes/schedulerRoutes.js
+++ b/server/routes/schedulerRoutes.js
@@ -1,14 +1,15 @@
 import express from 'express';
 import { readSchedulerConfig, writeSchedulerConfig } from '../utils/schedulerUtils.js';
+import { requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.get('/config', (req, res) => {
+router.get('/config', requireAuth, (req, res) => {
   const config = readSchedulerConfig();
   res.json(config);
 });
 
-router.put('/config', (req, res) => {
+router.put('/config', requireAuth, (req, res) => {
   const { startTime, stopTime, callsPerHour } = req.body;
   if (!startTime || !stopTime || typeof callsPerHour !== 'number') {
     return res.status(400).json({ error: 'Invalid config' });

--- a/server/routes/simulationRoutes.js
+++ b/server/routes/simulationRoutes.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import { simulateCall } from '../controllers/simulationController.js';
+import { requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.post('/call', simulateCall);
+router.post('/call', requireAuth, simulateCall);
 
 export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ import phoneRoutes from './routes/phoneRoutes.js';
 import simulationRoutes from './routes/simulationRoutes.js';
 import webhookRoutes from './routes/webhook.js';
 import schedulerRoutes from './routes/schedulerRoutes.js';
+import authRoutes from './routes/auth.js';
 import { startScheduler } from './services/callScheduler.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -40,6 +41,7 @@ app.use(express.urlencoded({ extended: true })); // Parses application/x-www-for
 app.set('io', io);
 
 // ✅ Routes
+app.use('/api/auth', authRoutes);
 app.use('/api/leads/webhook', webhookRoutes);
 app.use('/api/leads', leadsRoutes);
 app.use('/api/actions', actionsRoutes);


### PR DESCRIPTION
## Summary
- implement in-memory token auth with login/logout endpoints and middleware
- secure lead management routes and other API endpoints with auth checks
- add client-side login flow and attach bearer tokens to API requests

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` (client) *(fails: 97 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf952a4588832784a0a60391e3c942