### PR TITLE
feat: add simple UI animations

### DIFF
--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -4,6 +4,7 @@ import {
   ModalBody, ModalFooter, useDisclosure, useColorModeValue,
   VStack, Button, IconButton, Avatar, Divider, Input
 } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
 import { PhoneIcon, CloseIcon } from '@chakra-ui/icons';
 import { FiFileText } from 'react-icons/fi';
 import { useRef, useEffect, useState } from 'react';
@@ -24,6 +25,8 @@ function SoundWave() {
     </Box>
   );
 }
+
+const MotionBox = motion(Box);
 
 export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
   const reportRef = useRef();
@@ -156,20 +159,26 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
 
   return (
     <>
-      <Card
+      <MotionBox
         ref={scrollRef}
-        bg={cardBg}
-        border="1px solid"
-        borderColor={useColorModeValue("gray.200", "gray.600")}
-        borderRadius="xl"
-        boxShadow="sm"
-        _hover={{ shadow: "lg", transform: "scale(1.01)" }}
-        transition="all 0.2s ease"
-        cursor="pointer"
-        onClick={openReport}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        whileHover={{ scale: 1.02 }}
+        transition={{ duration: 0.3 }}
+        w="100%"
       >
-        <CardBody>
-          <Stack spacing={2} fontSize="sm">
+        <Card
+          bg={cardBg}
+          border="1px solid"
+          borderColor={useColorModeValue("gray.200", "gray.600")}
+          borderRadius="xl"
+          boxShadow="sm"
+          _hover={{ shadow: "lg" }}
+          cursor="pointer"
+          onClick={openReport}
+        >
+          <CardBody>
+            <Stack spacing={2} fontSize="sm">
             <Heading size="sm" noOfLines={1} color={textColor}>
               🧍 {lead.firstName} {lead.lastName}
             </Heading>
@@ -199,9 +208,10 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
                 View Report
               </Button>
             </Stack>
-          </Stack>
-        </CardBody>
-      </Card>
+            </Stack>
+          </CardBody>
+        </Card>
+      </MotionBox>
 
       <Modal isOpen={isCallOpen} onClose={closeCall} size="md" isCentered>
         <ModalOverlay />

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Box, Button, FormControl, FormLabel, Heading, Input, VStack, useToast } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
 import PropTypes from 'prop-types';
 
 export default function Login({ onLogin }) {
@@ -24,9 +25,21 @@ export default function Login({ onLogin }) {
     }
   };
 
+  const MotionBox = motion(Box);
+
   return (
     <Box minH="100vh" display="flex" alignItems="center" justifyContent="center">
-      <Box as="form" onSubmit={handleSubmit} p={8} borderWidth="1px" borderRadius="lg" boxShadow="md">
+      <MotionBox
+        as="form"
+        onSubmit={handleSubmit}
+        p={8}
+        borderWidth="1px"
+        borderRadius="lg"
+        boxShadow="md"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
         <VStack spacing={4}>
           <Heading size="md">Sign In</Heading>
           <FormControl>
@@ -39,7 +52,7 @@ export default function Login({ onLogin }) {
           </FormControl>
           <Button type="submit" colorScheme="blue" w="full">Login</Button>
         </VStack>
-      </Box>
+      </MotionBox>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add framer-motion animations to lead cards for fade/hover effects
- animate login form entry for a smoother sign-in experience

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 'showArrow' is missing in props validation etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb2b04e94832788bfb0d312c38096