### PR TITLE
Add AI-generated lead summaries

### DIFF
--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -35,6 +35,8 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
   const [followUpDateInput, setFollowUpDateInput] = useState(
     lead.followUpDate ? new Date(lead.followUpDate).toISOString().slice(0, 16) : ''
   );
+  const [aiSummary, setAiSummary] = useState('');
+  const [isSummaryLoading, setSummaryLoading] = useState(false);
 
   const { isOpen: isReportOpen, onOpen: openReport, onClose: closeReport } = useDisclosure();
   const { isOpen: isCallOpen, onOpen: openCall, onClose: closeCall } = useDisclosure();
@@ -152,6 +154,21 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
       html2canvas: { scale: 2 },
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
     }).save();
+  };
+
+  const generateSummary = async () => {
+    setSummaryLoading(true);
+    try {
+      const res = await fetch(`http://localhost:3000/api/leads/${lead.id}/summary`, {
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+      });
+      const data = await res.json();
+      setAiSummary(data.summary || 'No summary available');
+    } catch (err) {
+      console.error('Failed to fetch summary:', err);
+    } finally {
+      setSummaryLoading(false);
+    }
   };
 
   return (
@@ -278,6 +295,19 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
                   <Text>No AI interaction history.</Text>
                 )}
               </Box>
+
+              <Divider />
+
+              {aiSummary ? (
+                <Box>
+                  <Heading size="sm" mb={2}>🤖 AI Summary</Heading>
+                  <Text fontSize="sm" whiteSpace="pre-wrap">{aiSummary}</Text>
+                </Box>
+              ) : (
+                <Button size="sm" onClick={generateSummary} isLoading={isSummaryLoading}>
+                  Generate AI Summary
+                </Button>
+              )}
 
               {lead.notes && (
                 <>

--- a/server/controllers/leadController.js
+++ b/server/controllers/leadController.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { readDataFile, writeDataFile } from '../utils/fileHelpers.js';
 import { logAction } from '../utils/logger.js';
+import { summarizeLead } from '../services/openaiClients.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -149,4 +150,20 @@ export const getLeadById = (req, res) => {
   res.json(lead);
 };
 
+
+export const getLeadSummary = async (req, res) => {
+  try {
+    const id = Number(req.params.id);
+    const leads = JSON.parse(fs.readFileSync(leadsFile, 'utf-8'));
+    const lead = leads.find(l => l.id === id);
+    if (!lead) {
+      return res.status(404).json({ error: 'Lead not found' });
+    }
+    const summary = await summarizeLead(lead);
+    res.json({ summary });
+  } catch (err) {
+    console.error('Summary error:', err);
+    res.status(500).json({ error: 'Failed to generate summary' });
+  }
+};
 

--- a/server/routes/leads.js
+++ b/server/routes/leads.js
@@ -4,6 +4,7 @@ import {
   addLead,
   updateLead,
   getLeadById, // ← You need this
+  getLeadSummary,
 } from '../controllers/leadController.js';
 import { requireAuth } from '../middleware/auth.js';
 
@@ -11,6 +12,8 @@ const router = express.Router();
 
 router.get('/', requireAuth, getLeads);
 router.post('/', requireAuth, addLead);
+
+router.get('/:id/summary', requireAuth, getLeadSummary);
 
 // ✅ Add this route
 router.get('/:id', requireAuth, getLeadById);

--- a/server/services/openaiClients.js
+++ b/server/services/openaiClients.js
@@ -34,3 +34,38 @@ export const askAI = async (messages) => {
     throw new Error('Failed to generate AI response');
   }
 };
+
+export const summarizeLead = async (lead) => {
+  try {
+    const historyText = (lead.callHistory || [])
+      .map(entry => {
+        const ai = typeof entry.ai === 'object' ? entry.ai.aiReply : entry.ai;
+        return `Prospect: ${entry.user}\nAgent: ${ai}`;
+      })
+      .join('\n');
+
+    const messages = [
+      {
+        role: 'system',
+        content:
+          "You summarize conversations between solar reps and homeowners. Provide a short summary and suggest a follow-up step.",
+      },
+      {
+        role: 'user',
+        content: historyText || 'No conversation history.',
+      },
+    ];
+
+    const response = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages,
+      temperature: 0.7,
+      max_tokens: 120,
+    });
+
+    return response.choices[0].message.content.trim();
+  } catch (err) {
+    console.error('❌ OpenAI Summary Error:', err.message);
+    return 'Summary unavailable';
+  }
+};


### PR DESCRIPTION
## Summary
- Add OpenAI helper to summarize lead call history and suggest next steps
- Expose `/api/leads/:id/summary` endpoint for summarizing a lead
- Provide UI button in lead report modal to request and display AI summary

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: react/prop-types errors)


------
https://chatgpt.com/codex/tasks/task_e_68bfb6b61f648327adedf1ae77c46bd8