### PR TITLE
Support plaintext admin password with hash fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ coverage/
 
 # Local dev artifacts
 *.local
-*.test.*
 *.bak
 *.swp
 *.tmp

--- a/server/README.md
+++ b/server/README.md
@@ -30,7 +30,7 @@ The server will start on:
 
 🛠️ Environment Variables
 
-Create a `.env` file (or configure your deployment environment) with the following variables before starting the server:
+Create a `.env` file **one level above the `server` directory** (or configure your deployment environment) with the following variables before starting the server. The file must define `ADMIN_USERNAME` and either `ADMIN_PASSWORD_HASH` (SHA-256) or `ADMIN_PASSWORD`:
 
 ```
 TWILIO_SID=<your Twilio account SID>
@@ -39,6 +39,8 @@ TWILIO_PHONE=<your Twilio phone number>
 SERVER_BASE_URL=<public base URL of this server>
 ADMIN_USERNAME=<admin login name>
 ADMIN_PASSWORD_HASH=<sha256 hash of admin password>
+# or
+ADMIN_PASSWORD=<admin password>
 ```
 
 `SERVER_BASE_URL` is used to construct webhook URLs (e.g., Twilio voice and status callbacks).

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js",
     "dev": "nodemon server.js"
   },

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -9,9 +9,16 @@ const hash = (str) => crypto.createHash('sha256').update(str).digest('hex');
 router.post('/login', (req, res) => {
   const { username, password } = req.body;
   const storedUser = process.env.ADMIN_USERNAME;
-  const storedHash = process.env.ADMIN_PASSWORD_HASH;
+  const storedHash = process.env.ADMIN_PASSWORD
+    ? hash(process.env.ADMIN_PASSWORD)
+    : process.env.ADMIN_PASSWORD_HASH;
 
-  if (!username || !password || username !== storedUser || hash(password) !== storedHash) {
+  if (
+    !username ||
+    !password ||
+    username !== storedUser ||
+    hash(password) !== storedHash
+  ) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
 

--- a/server/routes/auth.test.js
+++ b/server/routes/auth.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import crypto from 'crypto';
+import authRouter from './auth.js';
+
+const hash = (str) => crypto.createHash('sha256').update(str).digest('hex');
+
+const makeServer = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', authRouter);
+  return app.listen(0);
+};
+
+test('login succeeds with hashed and plaintext configurations', async (t) => {
+  await t.test('with ADMIN_PASSWORD_HASH', async () => {
+    process.env.ADMIN_USERNAME = 'admin';
+    delete process.env.ADMIN_PASSWORD;
+    process.env.ADMIN_PASSWORD_HASH = hash('secret');
+
+    const server = makeServer();
+    const { port } = server.address();
+    const res = await fetch(`http://localhost:${port}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password: 'secret' }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.token);
+    server.close();
+  });
+
+  await t.test('with ADMIN_PASSWORD', async () => {
+    process.env.ADMIN_USERNAME = 'admin';
+    process.env.ADMIN_PASSWORD = 'secret';
+    delete process.env.ADMIN_PASSWORD_HASH;
+
+    const server = makeServer();
+    const { port } = server.address();
+    const res = await fetch(`http://localhost:${port}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password: 'secret' }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.token);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- hash `ADMIN_PASSWORD` when provided and fall back to `ADMIN_PASSWORD_HASH`
- document env file location and ability to use plain or hashed admin password
- add login tests for hashed and plaintext credentials

## Testing
- `npm test` *(fails: Cannot find package '/workspace/lead-caller/server/node_modules/express/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_68bfc0e2b9388327998617ff127418d1