### PR TITLE
Handle non-array lead responses

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,7 +35,8 @@ import {
 const COLORS = ["#e60082", "#00bcd4", "#F6AD55", "#38A169", "#805AD5", "#FFB800"];
 
 function getStatusData(leads) {
-  const grouped = leads.reduce((acc, lead) => {
+  const safeLeads = Array.isArray(leads) ? leads : [];
+  const grouped = safeLeads.reduce((acc, lead) => {
     const key = lead.status || "New";
     acc[key] = (acc[key] || 0) + 1;
     return acc;
@@ -83,9 +84,24 @@ function App({ onLogout }) {
   }, []);
 
   useEffect(() => {
-    fetch("http://localhost:3000/api/leads", {
-      headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
-    }).then(res => res.json()).then(setLeads);
+    const fetchLeads = async () => {
+      try {
+        const res = await fetch("http://localhost:3000/api/leads", {
+          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` }
+        });
+        if (!res.ok) {
+          console.error('Failed to fetch leads:', res.status);
+          setLeads([]);
+          return;
+        }
+        const data = await res.json();
+        setLeads(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error('Error fetching leads:', err);
+        setLeads([]);
+      }
+    };
+    fetchLeads();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Avoid reduce errors by guarding against non-array lead data
- Fetch leads with error handling to default to an empty list on failure

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client) *(fails: 97 errors, 5 warnings)*
- `npm test` (server) *(fails: Cannot find package 'express')*
- `npm install` (server) *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcbaaef888327967f5099db133858