### PR TITLE
Use brand color scheme for UI components

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -255,7 +255,7 @@ function App({ onLogout }) {
                   ))}
                 </SimpleGrid>
 
-                <Button size="sm" colorScheme="blue" onClick={() => setShowLeads(true)}>Open Lead Manager</Button>
+                <Button size="sm" colorScheme="brand" onClick={() => setShowLeads(true)}>Open Lead Manager</Button>
               </Box>
             )}
           </Box>

--- a/client/src/components/AutoCallMenu.jsx
+++ b/client/src/components/AutoCallMenu.jsx
@@ -85,7 +85,7 @@ export default function AutoCallMenu() {
             <NumberInputField name="callsPerHour" />
           </NumberInput>
         </FormControl>
-        <Button type="submit" colorScheme="blue">Save</Button>
+        <Button type="submit" colorScheme="brand">Save</Button>
         {message && (
           <Alert status={message.type}>
             <AlertIcon />

--- a/client/src/components/CallSession.jsx
+++ b/client/src/components/CallSession.jsx
@@ -104,7 +104,7 @@ export default function CallSession({ lead, onClose }) {
         {/* Progress Bar */}
         <Progress
           value={(currentIndex / questions.length) * 100}
-          colorScheme="blue"
+          colorScheme="brand"
           size="sm"
           borderRadius="full"
           mb={6}
@@ -112,7 +112,7 @@ export default function CallSession({ lead, onClose }) {
 
         {/* Current Question Block */}
         <Box bg={cardBg} p={6} borderRadius="xl" border="1px solid" borderColor={borderColor}>
-          <Badge colorScheme="blue" fontSize="0.75rem" mb={2}>
+          <Badge colorScheme="brand" fontSize="0.75rem" mb={2}>
             Question {currentIndex + 1} of {questions.length}
           </Badge>
           <Text fontSize="md" fontWeight="semibold" color={textColor}>
@@ -131,7 +131,7 @@ export default function CallSession({ lead, onClose }) {
           <Button
             mt={4}
             onClick={handleNext}
-            colorScheme="blue"
+            colorScheme="brand"
             size="sm"
             alignSelf="flex-end"
           >

--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -215,7 +215,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
               </Button>
               <Button
                 size="xs"
-                colorScheme="blue"
+                colorScheme="brand"
                 onClick={(e) => {
                   e.stopPropagation();
                   openReport();
@@ -359,7 +359,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
           </Box>
 
           <ModalFooter>
-            <Button colorScheme="blue" onClick={downloadPDF}>
+            <Button colorScheme="brand" onClick={downloadPDF}>
               Download PDF
             </Button>
           </ModalFooter>

--- a/client/src/components/LeadForm.jsx
+++ b/client/src/components/LeadForm.jsx
@@ -204,7 +204,7 @@ export default function LeadForm({ onNewLead }) {
           </GridItem>
 
           <GridItem colSpan={{ base: 1, md: 2 }}>
-            <Button w="full" type="submit" colorScheme="blue">
+            <Button w="full" type="submit" colorScheme="brand">
               Submit Lead
             </Button>
           </GridItem>

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -50,7 +50,7 @@ export default function Login({ onLogin }) {
             <FormLabel>Password</FormLabel>
             <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
           </FormControl>
-          <Button type="submit" colorScheme="blue" w="full">Login</Button>
+          <Button type="submit" colorScheme="brand" w="full">Login</Button>
         </VStack>
       </MotionBox>
     </Box>


### PR DESCRIPTION
## Summary
- Replace Chakra UI `colorScheme="blue"` usages with `colorScheme="brand"` across key components
- Ensure progress bar, badge, and action buttons use brand palette

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ❌ `npm run lint` *(97 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcbbee958832796f4f0793ec993e9