### PR TITLE
Add soft delete endpoint for leads

### DIFF
--- a/server/routes/leads.js
+++ b/server/routes/leads.js
@@ -5,6 +5,7 @@ import {
   updateLead,
   getLeadById, // ← You need this
   getLeadSummary,
+  softDeleteLead,
 } from '../controllers/leadController.js';
 import { requireAuth } from '../middleware/auth.js';
 
@@ -20,5 +21,7 @@ router.get('/:id', requireAuth, getLeadById);
 
 // ✅ Make sure this route already exists
 router.put('/:id', requireAuth, updateLead);
+
+router.delete('/:id', requireAuth, softDeleteLead);
 
 export default router;


### PR DESCRIPTION
## Summary
- Import `softDeleteLead` controller in leads routes and expose DELETE route for lead removal

## Testing
- `npm test` *(fails: Cannot find package 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcec04458832782d7f323a0ee86ef