### PR TITLE
Add delete functionality for leads

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -126,6 +126,16 @@ function App({ onLogout }) {
     setLeads(prev => prev.map(l => l.id === updated.id ? updated : l));
   };
 
+  const deleteLead = async (id) => {
+    await fetch(`http://localhost:3000/api/leads/${id}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('token')}`
+      }
+    });
+    setLeads(prev => prev.filter(l => l.id !== id));
+  };
+
   const total = leads.length;
   const grouped = leads.reduce((acc, lead) => {
     const key = lead.status || "New";
@@ -221,7 +231,13 @@ function App({ onLogout }) {
           </Stack>
 
           <Collapse in={showLeads}>
-            <LeadList leads={leads} onUpdateLead={updateLead} filter={filter} socket={socketRef.current} />
+            <LeadList
+              leads={leads}
+              onUpdateLead={updateLead}
+              onDeleteLead={deleteLead}
+              filter={filter}
+              socket={socketRef.current}
+            />
           </Collapse>
 
           {!showLeads && (

--- a/client/src/components/LeadCard.jsx
+++ b/client/src/components/LeadCard.jsx
@@ -2,7 +2,7 @@ import {
   Card, CardBody, Heading, Text, Stack, Box, Badge,
   Modal, ModalOverlay, ModalContent, ModalHeader,
   ModalBody, ModalFooter, useDisclosure, useColorModeValue,
-  VStack, Button, IconButton, Avatar, Divider, Input
+  VStack, Button, IconButton, Avatar, Divider, Input, useToast
 } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { PhoneIcon, CloseIcon } from '@chakra-ui/icons';
@@ -28,7 +28,7 @@ function SoundWave() {
 
 const MotionBox = motion(Box);
 
-export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
+export default function LeadCard({ lead, onUpdateLead, onDeleteLead, scrollRef, socket }) {
   const reportRef = useRef();
   const pollingRef = useRef(null);
 
@@ -47,6 +47,7 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
   const cardBg = useColorModeValue("white", "gray.700");
   const modalBg = useColorModeValue("white", "gray.800");
   const textColor = useColorModeValue("gray.800", "gray.100");
+  const toast = useToast();
 
   useEffect(() => {
     if (scrollRef?.current) {
@@ -203,32 +204,51 @@ export default function LeadCard({ lead, onUpdateLead, scrollRef, socket }) {
             <Badge fontSize="0.7em" colorScheme={lead.status === "Qualified" ? "green" : "yellow"}>
               {lead.status}
             </Badge>
-            <Stack direction="row" spacing={2} mt={3}>
-              <Button
-                size="xs"
-                variant="outline"
-                leftIcon={<PhoneIcon />}
-                onClick={startCall}
-                isLoading={isCalling}
-              >
-                Call
-              </Button>
-              <Button
-                size="xs"
-                colorScheme="brand"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openReport();
-                }}
-                leftIcon={<FiFileText />}
-              >
-                View Report
-              </Button>
-            </Stack>
-            </Stack>
-          </CardBody>
-        </Card>
-      </MotionBox>
+          <Stack direction="row" spacing={2} mt={3}>
+            <Button
+              size="xs"
+              variant="outline"
+              leftIcon={<PhoneIcon />}
+              onClick={startCall}
+              isLoading={isCalling}
+            >
+              Call
+            </Button>
+            <Button
+              size="xs"
+              colorScheme="brand"
+              onClick={(e) => {
+                e.stopPropagation();
+                openReport();
+              }}
+              leftIcon={<FiFileText />}
+            >
+              View Report
+            </Button>
+            <Button
+              size="xs"
+              colorScheme="red"
+              variant="outline"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (window.confirm("Delete this lead?")) {
+                  onDeleteLead(lead.id);
+                  toast({
+                    title: "Lead removed",
+                    status: "info",
+                    duration: 3000,
+                    isClosable: true,
+                  });
+                }
+              }}
+            >
+              Delete
+            </Button>
+          </Stack>
+          </Stack>
+        </CardBody>
+      </Card>
+    </MotionBox>
 
       <Modal isOpen={isCallOpen} onClose={closeCall} size="md" isCentered>
         <ModalOverlay />

--- a/client/src/components/LeadList.jsx
+++ b/client/src/components/LeadList.jsx
@@ -26,7 +26,7 @@ const STATUS_ICONS = {
   New: FiStar,
 };
 
-export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All", socket }) {
+export default function LeadList({ leads, onUpdateLead, onDeleteLead, scrollRef, filter = "All", socket }) {
   const grouped = leads.reduce((acc, lead) => {
     const status = (lead.status || "New").trim();
     if (!acc[status]) acc[status] = [];
@@ -89,6 +89,7 @@ export default function LeadList({ leads, onUpdateLead, scrollRef, filter = "All
                     key={lead.id}
                     lead={lead}
                     onUpdateLead={onUpdateLead}
+                    onDeleteLead={onDeleteLead}
                     scrollRef={isLast ? scrollRef : undefined}
                     socket={socket}
                   />


### PR DESCRIPTION
## Summary
- Allow deleting leads via `deleteLead` API call and propagate to UI
- Enable `LeadCard` to display a Delete button with confirmation and toast

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 100 errors)

------
https://chatgpt.com/codex/tasks/task_e_68bfceeb99508327b10c4a755b8ecde6