### PR TITLE
Add unit tests for lead utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ coverage/
 
 # Local dev artifacts
 *.local
-*.test.*
 *.bak
 *.swp
 *.tmp

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js",
     "dev": "nodemon server.js"
   },

--- a/server/utils/leadUtils.test.js
+++ b/server/utils/leadUtils.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readLeads, updateLeadById, findLeadByPhone } from './leadUtils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const leadsFile = path.join(__dirname, '../data/leads.json');
+
+test('updateLeadById updates status and persists to file', () => {
+  const originalData = fs.readFileSync(leadsFile, 'utf-8');
+  const leads = JSON.parse(originalData);
+  const [firstLead] = leads;
+  try {
+    const updatedLead = updateLeadById(firstLead.id, { status: 'Tested' });
+    assert.strictEqual(updatedLead.status, 'Tested');
+
+    const saved = readLeads().find(l => l.id === firstLead.id);
+    assert.strictEqual(saved.status, 'Tested');
+  } finally {
+    fs.writeFileSync(leadsFile, originalData, 'utf-8');
+  }
+});
+
+test('findLeadByPhone returns matching lead', () => {
+  const lead = findLeadByPhone('+19199314345');
+  assert.ok(lead);
+  assert.strictEqual(lead.phone, '+19199314345');
+});


### PR DESCRIPTION
## Summary
- add node test script to server package.json
- cover lead utils with automated tests

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68bfbcb794148327992b2bdbfdd8a4bc