### PR TITLE
feat: use brand token in toaster spinner

### DIFF
--- a/client/src/components/ui/toaster.jsx
+++ b/client/src/components/ui/toaster.jsx
@@ -21,7 +21,7 @@ export const Toaster = () => {
         {(toast) => (
           <Toast.Root width={{ md: 'sm' }}>
             {toast.type === 'loading' ? (
-              <Spinner size='sm' color='blue.solid' />
+              <Spinner size='sm' color='brand.500' />
             ) : (
               <Toast.Indicator />
             )}


### PR DESCRIPTION
## Summary
- use Sunrun brand token for loading spinner in toaster

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client) *(fails: prop-types errors in unrelated files)*
- `npm test` (server) *(fails: cannot find package 'express')*
- `npm install` (server) *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-cron)*

------
https://chatgpt.com/codex/tasks/task_e_68c07228bd148327a8725a301ba7219c