### PR TITLE
Prevent duplicate lead phone numbers and surface CSV upload errors

### DIFF
--- a/client/src/components/LeadCsvUpload.jsx
+++ b/client/src/components/LeadCsvUpload.jsx
@@ -24,6 +24,7 @@ export default function LeadCsvUpload({ onNewLead }) {
       complete: async (results) => {
         let success = 0;
         let errors = 0;
+        let duplicates = 0;
 
         for (const row of results.data) {
           if (Object.values(row).every((val) => val === undefined || val === '')) continue;
@@ -50,6 +51,12 @@ export default function LeadCsvUpload({ onNewLead }) {
               },
               body: JSON.stringify(lead),
             });
+
+            if (res.status === 409) {
+              duplicates += 1;
+              continue;
+            }
+
             const data = await res.json();
             if (data.success) {
               success += 1;
@@ -62,10 +69,14 @@ export default function LeadCsvUpload({ onNewLead }) {
           }
         }
 
+        const message =
+          `${success} leads added` +
+          `${duplicates ? `, ${duplicates} duplicates` : ''}` +
+          `${errors ? `, ${errors} failed` : ''}.`;
         toast({
           title: 'CSV Upload Complete',
-          description: `${success} leads added${errors ? `, ${errors} failed` : ''}.`,
-          status: errors ? 'warning' : 'success',
+          description: message,
+          status: duplicates || errors ? 'warning' : 'success',
           duration: 5000,
           isClosable: true,
         });

--- a/client/src/components/LeadForm.jsx
+++ b/client/src/components/LeadForm.jsx
@@ -69,6 +69,17 @@ export default function LeadForm({ onNewLead }) {
 
       const data = await res.json();
 
+      if (res.status === 409) {
+        toast({
+          title: 'Phone already exists',
+          description: data.error,
+          status: 'warning',
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+
       if (data.success) {
         onNewLead(data.lead);
         setFirstName('');

--- a/server/controllers/leadController.js
+++ b/server/controllers/leadController.js
@@ -35,11 +35,18 @@ export const addLead = (req, res) => {
   try {
     const leads = JSON.parse(fs.readFileSync(leadsFile, 'utf-8'));
 
+    const normalizePhone = (p) => String(p).replace(/\D/g, '');
+    const normalizedPhone = normalizePhone(phone);
+    const exists = leads.some(l => normalizePhone(l.phone) === normalizedPhone);
+    if (exists) {
+      return res.status(409).json({ error: 'Phone already exists' });
+    }
+
     const newLead = {
       id: Date.now(),
       firstName,
       lastName,
-      phone,
+      phone: normalizedPhone,
       address,
       note,
       status: "New",


### PR DESCRIPTION
## Summary
- reject new leads with duplicate phone numbers by normalizing digits and returning HTTP 409
- show duplicate counts and failures after CSV uploads and handle duplicate phone submissions in lead form

## Testing
- `cd server && npm test` *(fails: Cannot find package 'express' from routes/auth.test.js)*
- `cd client && npm run lint` *(fails: 100 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c07640a21c8327a0eabea405f0b663