### PR TITLE
Enhance auto call settings modal

### DIFF
--- a/server/data/dev/scheduler.json
+++ b/server/data/dev/scheduler.json
@@ -1,5 +1,7 @@
 {
   "startTime": "09:00",
   "stopTime": "17:00",
-  "callsPerHour": 60
+  "callsPerHour": 60,
+  "enabled": false,
+  "days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
 }

--- a/server/data/prod/scheduler.json
+++ b/server/data/prod/scheduler.json
@@ -1,5 +1,7 @@
 {
   "startTime": "09:00",
   "stopTime": "17:00",
-  "callsPerHour": 60
+  "callsPerHour": 60,
+  "enabled": false,
+  "days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
 }

--- a/server/routes/schedulerRoutes.js
+++ b/server/routes/schedulerRoutes.js
@@ -10,8 +10,8 @@ router.get('/config', requireAuth, (req, res) => {
 });
 
 router.put('/config', requireAuth, (req, res) => {
-  const { startTime, stopTime, callsPerHour } = req.body;
-  if (!startTime || !stopTime || typeof callsPerHour !== 'number') {
+  const { startTime, stopTime, callsPerHour, enabled, days } = req.body;
+  if (!startTime || !stopTime || typeof callsPerHour !== 'number' || !Array.isArray(days)) {
     return res.status(400).json({ error: 'Invalid config' });
   }
   if (startTime >= stopTime) {
@@ -20,7 +20,7 @@ router.put('/config', requireAuth, (req, res) => {
   if (callsPerHour <= 0) {
     return res.status(400).json({ error: 'callsPerHour must be greater than 0' });
   }
-  const config = { startTime, stopTime, callsPerHour };
+  const config = { startTime, stopTime, callsPerHour, enabled: Boolean(enabled), days };
   writeSchedulerConfig(config);
   res.json(config);
 });

--- a/server/services/callScheduler.js
+++ b/server/services/callScheduler.js
@@ -13,8 +13,13 @@ export function startScheduler() {
   // Run job every minute
   cron.schedule('* * * * *', async () => {
     const config = readSchedulerConfig();
-    const { startTime, stopTime, callsPerHour } = config;
+    const { startTime, stopTime, callsPerHour, enabled, days } = config;
     const now = new Date();
+
+    if (!enabled) return;
+    const dayMap = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const today = dayMap[now.getDay()];
+    if (Array.isArray(days) && !days.includes(today)) return;
 
     const [startHour, startMinute] = startTime.split(':').map(Number);
     const [stopHour, stopMinute] = stopTime.split(':').map(Number);

--- a/server/utils/schedulerUtils.js
+++ b/server/utils/schedulerUtils.js
@@ -12,10 +12,24 @@ const configFile = process.env.SCHEDULER_FILE
 
 export function readSchedulerConfig() {
   if (!fs.existsSync(configFile)) {
-    return { startTime: '09:00', stopTime: '17:00', callsPerHour: 60 };
+    return {
+      startTime: '09:00',
+      stopTime: '17:00',
+      callsPerHour: 60,
+      enabled: false,
+      days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+    };
   }
   const data = fs.readFileSync(configFile, 'utf-8');
-  return JSON.parse(data);
+  const parsed = JSON.parse(data);
+  return {
+    startTime: '09:00',
+    stopTime: '17:00',
+    callsPerHour: 60,
+    enabled: false,
+    days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    ...parsed
+  };
 }
 
 export function writeSchedulerConfig(config) {


### PR DESCRIPTION
## Summary
- Revamp auto call settings modal with toggle, day selection, and styled layout
- Persist `enabled` flag and active days in scheduler config and API
- Ensure scheduler respects enabled state and chosen days

## Testing
- `npm test` (server) *(fails: Cannot find package 'express' - npm install 403)*
- `npm test` (client) *(fails: Missing script 'test')*
- `npm run lint` (client) *(fails: 100 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ea64b8c48327ab92503e3702c065